### PR TITLE
Add bounds check to openmc_cell_set_temperature routine

### DIFF
--- a/openmc/capi/__init__.py
+++ b/openmc/capi/__init__.py
@@ -86,6 +86,19 @@ def _error_handler(err, func, args):
     elif err == _error_code('e_tally_invalid_id'):
         raise KeyError("No tally exists with ID={}.".format(args[0]))
 
+    elif err == _error_code('e_invalid_size'):
+        raise MemoryError("Array size mismatch with memory allocated.")
+
+    elif err == _error_code('e_cell_no_material'):
+        raise GeometryError("Operation on cell requires that it be filled"
+                            " with a material.")
+
+    elif err == _error_code('w_below_min_bound'):
+        warn("Data has not been loaded beyond lower bound of {}.".format(args[0]))
+
+    elif err == _error_code('w_above_max_bound'):
+        warn("Data has not been loaded beyond upper bound of {}.".format(args[0]))
+
     elif err < 0:
         raise Exception("Unknown error encountered (code {}).".format(err))
 


### PR DESCRIPTION
Added additional checks to the `openmc_cell_set_temperature` subroutine so ensure that if a cell is set to a temperature that is outside the bounds of the cross sections that were loaded, that the min/max available temperature (based on which direction the bounds are exceeded) are used to set the temperature. Because cross sections are not necessarily available for every nuclide at the same temperatures, this modification uses the "lowest common denominator" for choosing which temperature to set the cell to - the maximum of the minimum available temps, or the minimum of the maximum available temps. Two new error codes were added to be able to provide more detailed error messages to a calling program as to whether the bounds were exceeded on the low-end or the high-end.

This subroutine should also not work if the cell is filled with another universe, so a new error code was added to handle this case.

Error messages were added for the new error codes to the Python C-API. The `INVALID_SIZE` error code is not actually used in this pull request, but I plan to use it for some coupling routines, so thought I could add it now.

Refs #7