### PR TITLE
Remove nearest temperature interpolation

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -812,24 +812,6 @@ a material default temperature.
 
   *Default*: 293.6 K
 
-.. _temperature_method:
-
---------------------------------
-``<temperature_method>`` Element
---------------------------------
-
-The ``<temperature_method>`` element has an accepted value of "nearest" or
-"interpolation". A value of "nearest" indicates that for each
-cell, the nearest temperature at which cross sections are given is to be
-applied, within a given tolerance (see :ref:`temperature_tolerance`). A value of
-"interpolation" indicates that cross sections are to be linear-linear
-interpolated between temperatures at which nuclear data are present (see
-:ref:`temperature_treatment`).
-
-  *Default*: "nearest"
-
-.. _temperature_multipole:
-
 -----------------------------------
 ``<temperature_multipole>`` Element
 -----------------------------------
@@ -859,11 +841,16 @@ where the temperatures might change from one iteration to the next.
 ``<temperature_tolerance>`` Element
 -----------------------------------
 
-The ``<temperature_tolerance>`` element specifies a tolerance in Kelvin that is
-to be applied when the "nearest" temperature method is used. For example, if a
-cell temperature is 340 K and the tolerance is 15 K, then the closest
-temperature in the range of 325 K to 355 K will be used to evaluate cross
-sections.
+The ``<temperature_tolerance>`` element specifies a fallback tolerance in
+Kelvin that is to be applied if linear interpolation of cross sections may not
+be used. Linear interpolation may not be used if only one temperature is
+available for a nuclide within the nuclear data library provided by
+OPENMC_CROSS_SECTIONS. Since most distributions of nuclear data for OpenMC do
+contain more than one temperature point for each nuclide, this option is
+primarily relevant to data used for testing OpenMC where only one temperature
+is present. If a cross section evaluation within this tolerance cannot be found
+and only one temperature is available for a given nuclide, OpenMC reports an
+error.
 
   *Default*: 10 K
 

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -106,12 +106,6 @@ constexpr int NUCLIDE_NONE  {-1};
 // ============================================================================
 // CROSS SECTION RELATED CONSTANTS
 
-// Temperature treatment method
-enum class TemperatureMethod {
-  NEAREST,
-  INTERPOLATION
-};
-
 // Reaction types
 enum ReactionType {
   REACTION_NONE = 0,

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -70,7 +70,7 @@ constexpr double EXTSRC_REJECT_FRACTION {0.05};
 // MATH AND PHYSICAL CONSTANTS
 
 // Values here are from the Committee on Data for Science and Technology
-// (CODATA) 2014 recommendation (doi:10.1103/RevModPhys.88.035009).
+// (CODATA) 2018 recommendation (https://physics.nist.gov/cuu/Constants/).
 
 // TODO: cmath::M_PI has 3 more digits precision than the Fortran constant we
 // use so for now we will reuse the Fortran constant until we are OK with
@@ -80,16 +80,16 @@ const double SQRT_PI {std::sqrt(PI)};
 constexpr double INFTY {std::numeric_limits<double>::max()};
 
 // Physical constants
-constexpr double MASS_NEUTRON     {1.00866491588}; // mass of a neutron in amu
-constexpr double MASS_NEUTRON_EV  {939.5654133e6}; // mass of a neutron in eV/c^2
-constexpr double MASS_PROTON      {1.007276466879}; // mass of a proton in amu
-constexpr double MASS_ELECTRON_EV {0.5109989461e6}; // electron mass energy equivalent in eV/c^2
-constexpr double FINE_STRUCTURE   {137.035999139}; // inverse fine structure constant
-constexpr double PLANCK_C         {1.2398419739062977e4}; // Planck's constant times c in eV-Angstroms
-constexpr double AMU              {1.660539040e-27}; // 1 amu in kg
+constexpr double MASS_NEUTRON     {1.00866491595}; // mass of a neutron in amu
+constexpr double MASS_NEUTRON_EV  {939.56542052e6}; // mass of a neutron in eV/c^2
+constexpr double MASS_PROTON      {1.007276466621}; // mass of a proton in amu
+constexpr double MASS_ELECTRON_EV {0.51099895000e6}; // electron mass energy equivalent in eV/c^2
+constexpr double FINE_STRUCTURE   {137.035999084}; // inverse fine structure constant
+constexpr double PLANCK_C         {1.2398419839593942e4}; // Planck's constant times c in eV-Angstroms
+constexpr double AMU              {1.66053906660e-27}; // 1 amu in kg
 constexpr double C_LIGHT          {2.99792458e8}; // speed of light in m/s
-constexpr double N_AVOGADRO       {0.6022140857}; // Avogadro's number in 10^24/mol
-constexpr double K_BOLTZMANN      {8.6173303e-5}; // Boltzmann constant in eV/K
+constexpr double N_AVOGADRO       {0.602214076}; // Avogadro's number in 10^24/mol
+constexpr double K_BOLTZMANN      {8.617333262e-5}; // Boltzmann constant in eV/K
 
 // Electron subshell labels
 constexpr std::array<const char*, 39> SUBSHELLS =  {

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -69,15 +69,13 @@ constexpr double EXTSRC_REJECT_FRACTION {0.05};
 // ============================================================================
 // MATH AND PHYSICAL CONSTANTS
 
-// Values here are from the Committee on Data for Science and Technology
-// (CODATA) 2018 recommendation (https://physics.nist.gov/cuu/Constants/).
-
-// TODO: cmath::M_PI has 3 more digits precision than the Fortran constant we
-// use so for now we will reuse the Fortran constant until we are OK with
-// modifying test results
-constexpr double PI {3.1415926535898};
+// TODO: replace with <numbers> when we go for C++20
+constexpr double PI {3.141592653589793238462643383279502884L};
 const double SQRT_PI {std::sqrt(PI)};
 constexpr double INFTY {std::numeric_limits<double>::max()};
+
+// Values here are from the Committee on Data for Science and Technology
+// (CODATA) 2018 recommendation (https://physics.nist.gov/cuu/Constants/).
 
 // Physical constants
 constexpr double MASS_NEUTRON     {1.00866491595}; // mass of a neutron in amu
@@ -110,8 +108,8 @@ constexpr int NUCLIDE_NONE  {-1};
 
 // Temperature treatment method
 enum class TemperatureMethod {
- NEAREST,
- INTERPOLATION
+  NEAREST,
+  INTERPOLATION
 };
 
 // Reaction types

--- a/include/openmc/distribution_multi.h
+++ b/include/openmc/distribution_multi.h
@@ -57,6 +57,8 @@ private:
 //! Uniform distribution on the unit sphere
 //==============================================================================
 
+Direction isotropic_direction(uint64_t* seed);
+
 class Isotropic : public UnitSphereDistribution {
 public:
   Isotropic() { };

--- a/include/openmc/secondary_uncorrelated.h
+++ b/include/openmc/secondary_uncorrelated.h
@@ -35,11 +35,9 @@ public:
 
   // Accessors
   AngleDistribution& angle() { return angle_; }
-  bool& fission() { return fission_; }
 private:
   AngleDistribution angle_; //!< Angle distribution
   std::unique_ptr<EnergyDistribution> energy_; //!< Energy distribution
-  bool fission_ {false}; //!< Whether distribution is use for fission
 };
 
 } // namespace openmc

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -89,8 +89,8 @@ extern std::unordered_set<int> sourcepoint_batch; //!< Batches when source shoul
 extern std::unordered_set<int> statepoint_batch; //!< Batches when state should be written
 extern std::unordered_set<int> source_write_surf_id; //!< Surface ids where sources will be written
 extern int64_t max_surface_particles;    //!< maximum number of particles to be banked on surfaces per process
-extern TemperatureMethod temperature_method;           //!< method for choosing temperatures
-extern double temperature_tolerance;     //!< Tolerance in [K] on choosing temperatures
+extern double
+  temperature_tolerance; //!< Tolerance in [K] on choosing temperatures.
 extern double temperature_default;       //!< Default T in [K]
 extern std::array<double, 2> temperature_range;  //!< Min/max T in [K] over which to load xs
 extern int trace_batch;                  //!< Batch to trace particle on

--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -178,20 +178,20 @@ ATOMIC_SYMBOL = {0: 'n', 1: 'H', 2: 'He', 3: 'Li', 4: 'Be', 5: 'B', 6: 'C',
 ATOMIC_NUMBER = {value: key for key, value in ATOMIC_SYMBOL.items()}
 
 # Values here are from the Committee on Data for Science and Technology
-# (CODATA) 2014 recommendation (doi:10.1103/RevModPhys.88.035009).
+# (CODATA) 2018 recommendation (https://physics.nist.gov/cuu/Constants/).
 
 # The value of the Boltzman constant in units of eV / K
-K_BOLTZMANN = 8.6173303e-5
+K_BOLTZMANN = 8.617333262e-5
 
 # Unit conversions
 EV_PER_MEV = 1.0e6
-JOULE_PER_EV = 1.6021766208e-19
+JOULE_PER_EV = 1.602176634e-19
 
 # Avogadro's constant
-AVOGADRO = 6.022140857e23
+AVOGADRO = 6.02214076e23
 
 # Neutron mass in units of amu
-NEUTRON_MASS = 1.00866491588
+NEUTRON_MASS = 1.00866491595
 
 # Used in atomic_mass function as a cache
 _ATOMIC_MASS = {}

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -242,14 +242,12 @@ Cell::temperature(int32_t instance) const
 void
 Cell::set_temperature(double T, int32_t instance, bool set_contained)
 {
-  if (settings::temperature_method == TemperatureMethod::INTERPOLATION) {
-    if (T < data::temperature_min) {
-      throw std::runtime_error{"Temperature is below minimum temperature at "
-        "which data is available."};
-    } else if (T > data::temperature_max) {
-      throw std::runtime_error{"Temperature is above maximum temperature at "
-        "which data is available."};
-    }
+  if (T < data::temperature_min) {
+    throw std::runtime_error {"Temperature is below minimum temperature at "
+                              "which data is available."};
+  } else if (T > data::temperature_max) {
+    throw std::runtime_error {"Temperature is above maximum temperature at "
+                              "which data is available."};
   }
 
   if (type_ == Fill::MATERIAL) {

--- a/src/distribution_multi.cpp
+++ b/src/distribution_multi.cpp
@@ -62,11 +62,6 @@ Direction PolarAzimuthal::sample(uint64_t* seed) const
   // Sample azimuthal angle
   double phi = phi_->sample(seed);
 
-  // If the reference direction is along the z-axis, rotate the aziumthal angle
-  // to match spherical coordinate conventions.
-  // TODO: apply this change directly to rotate_angle
-  if (u_ref_.x == 0 && u_ref_.y == 0) phi += 0.5*PI;
-
   return rotate_angle(u_ref_, mu, &phi, seed);
 }
 

--- a/src/distribution_multi.cpp
+++ b/src/distribution_multi.cpp
@@ -69,12 +69,17 @@ Direction PolarAzimuthal::sample(uint64_t* seed) const
 // Isotropic implementation
 //==============================================================================
 
-Direction Isotropic::sample(uint64_t* seed) const
+Direction isotropic_direction(uint64_t* seed)
 {
   double phi = 2.0*PI*prn(seed);
   double mu = 2.0*prn(seed) - 1.0;
   return {mu, std::sqrt(1.0 - mu*mu) * std::cos(phi),
       std::sqrt(1.0 - mu*mu) * std::sin(phi)};
+}
+
+Direction Isotropic::sample(uint64_t* seed) const
+{
+  return isotropic_direction(seed);
 }
 
 //==============================================================================

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -103,7 +103,6 @@ int openmc_finalize()
   settings::source_write = true;
   settings::survival_biasing = false;
   settings::temperature_default = 293.6;
-  settings::temperature_method = TemperatureMethod::NEAREST;
   settings::temperature_multipole = false;
   settings::temperature_range = {0.0, 0.0};
   settings::temperature_tolerance = 10.0;

--- a/src/math_functions.cpp
+++ b/src/math_functions.cpp
@@ -662,15 +662,9 @@ Direction rotate_angle(Direction u, double mu, const double* phi, uint64_t* seed
             mu*u.z - a*b*cosphi};
   } else {
     b = std::sqrt(1. - u.y*u.y);
-    return {mu*u.x + a*(u.x*u.y*cosphi + u.z*sinphi) / b,
-            mu*u.y - a*b*cosphi,
-            mu*u.z + a*(u.y*u.z*cosphi - u.x*sinphi) / b};
-    // TODO: use the following code to make PolarAzimuthal distributions match
-    // spherical coordinate conventions. Remove the related fixup code in
-    // PolarAzimuthal::sample.
-    //return {mu*u.x + a*(-u.x*u.y*sinphi + u.z*cosphi) / b,
-    //        mu*u.y + a*b*sinphi,
-    //        mu*u.z - a*(u.y*u.z*sinphi + u.x*cosphi) / b};
+    return {mu*u.x + a*(-u.x*u.y*sinphi + u.z*cosphi) / b,
+            mu*u.y + a*b*sinphi,
+            mu*u.z - a*(u.y*u.z*sinphi + u.x*cosphi) / b};
   }
 }
 

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -115,8 +115,10 @@ Nuclide::Nuclide(hid_t group, const std::vector<double>& temperature)
     }
   } else {
     for (double T_desired : temperature) {
-      auto T_upper_it = std::lower_bound(
-        temps_available.begin(), temps_available.end(), T_desired);
+      auto T_upper_it = std::lower_bound(temps_available.begin(),
+        temps_available.end(), T_desired, [](const double& l, const double& r) {
+          return std::round(l) < std::round(r);
+        });
       if (T_upper_it == temps_available.end() ||
           T_upper_it == temps_available.begin()) {
         fatal_error("Nuclear data library does not contain cross sections for " +
@@ -127,7 +129,7 @@ Nuclide::Nuclide(hid_t group, const std::vector<double>& temperature)
       // load both bounding temperatures.
       if (!contains(temps_to_read, *T_upper_it))
         temps_to_read.push_back(std::round(*T_upper_it));
-      if (T_desired != *T_upper_it) {
+      if (std::round(T_desired) != std::round(*T_upper_it)) {
         T_upper_it--;
         if (!contains(temps_to_read, *T_upper_it))
           temps_to_read.push_back(std::round(*T_upper_it));

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -809,9 +809,7 @@ void Nuclide::calculate_urr_xs(int i_temp, Particle& p) const
   // reuse random numbers for the same nuclide at different temperatures,
   // therefore preserving correlation of temperature in probability tables.
   p.stream_ = STREAM_URR_PTABLE;
-  //TODO: to maintain the same random number stream as the Fortran code this
-  //replaces, the seed is set with index_ + 1 instead of index_
-  double r = future_prn(static_cast<int64_t>(index_ + 1), *p.current_seed());
+  double r = future_prn(static_cast<int64_t>(index_), *p.current_seed());
   p.stream_ = STREAM_TRACKING;
 
   int i_low = 0;

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -3,6 +3,7 @@
 #include "openmc/bank.h"
 #include "openmc/bremsstrahlung.h"
 #include "openmc/constants.h"
+#include "openmc/distribution_multi.h"
 #include "openmc/eigenvalue.h"
 #include "openmc/endf.h"
 #include "openmc/error.h"
@@ -427,12 +428,7 @@ void sample_positron_reaction(Particle& p)
   }
 
   // Sample angle isotropically
-  double mu = 2.0*prn(p.current_seed()) - 1.0;
-  double phi = 2.0*PI*prn(p.current_seed());
-  Direction u;
-  u.x = mu;
-  u.y = std::sqrt(1.0 - mu*mu)*std::cos(phi);
-  u.z = std::sqrt(1.0 - mu*mu)*std::sin(phi);
+  Direction u = isotropic_direction(p.current_seed());
 
   // Create annihilation photon pair traveling in opposite directions
   p.create_secondary(p.wgt_, u, MASS_ELECTRON_EV, Particle::Type::photon);
@@ -714,13 +710,7 @@ void scatter(Particle& p, int i_nuclide)
     int i_nuc_mat = mat->mat_nuclide_index_[i_nuclide];
     if (mat->p0_[i_nuc_mat]) {
       // Sample isotropic-in-lab outgoing direction
-      double mu = 2.0*prn(p.current_seed()) - 1.0;
-      double phi = 2.0*PI*prn(p.current_seed());
-
-      // Change direction of particle
-      p.u().x = mu;
-      p.u().y = std::sqrt(1.0 - mu*mu)*std::cos(phi);
-      p.u().z = std::sqrt(1.0 - mu*mu)*std::sin(phi);
+      p.u() = isotropic_direction(p.current_seed());
       p.mu_ = u_old.dot(p.u());
     }
   }
@@ -1070,11 +1060,9 @@ void sample_fission_neutron(int i_nuclide, const Reaction& rx, double E_in, Part
   }
 
   // Sample azimuthal angle uniformly in [0, 2*pi) and assign angle
-  // TODO: use rotate_angle instead
-  double phi = 2.0*PI*prn(seed);
-  site->u.x = mu;
-  site->u.y = std::sqrt(1.0 - mu*mu) * std::cos(phi);
-  site->u.z = std::sqrt(1.0 - mu*mu) * std::sin(phi);
+  // TODO: account for dependence on incident neutron?
+  Direction ref(1., 0., 0.);
+  site->u = rotate_angle(ref, mu, nullptr, seed);
 }
 
 void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p)

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -1017,7 +1017,6 @@ void sample_fission_neutron(int i_nuclide, const Reaction& rx, double E_in, Part
   double nu_d = nuc->nu(E_in, Nuclide::EmissionMode::delayed);
   double beta = nu_d / nu_t;
 
-  double mu;
   if (prn(seed) < beta) {
     // ====================================================================
     // DELAYED NEUTRON SAMPLED
@@ -1043,52 +1042,35 @@ void sample_fission_neutron(int i_nuclide, const Reaction& rx, double E_in, Part
     // set the delayed group for the particle born from fission
     site->delayed_group = group;
 
-    int n_sample = 0;
-    while (true) {
-      // sample from energy/angle distribution -- note that mu has already been
-      // sampled above and doesn't need to be resampled
-      rx.products_[group].sample(E_in, site->E, mu, seed);
-
-      // resample if energy is greater than maximum neutron energy
-      constexpr int neutron = static_cast<int>(Particle::Type::neutron);
-      if (site->E < data::energy_max[neutron]) break;
-
-      // check for large number of resamples
-      ++n_sample;
-      if (n_sample == MAX_SAMPLE) {
-        // particle_write_restart(p)
-        fatal_error("Resampled energy distribution maximum number of times "
-          "for nuclide " + nuc->name_);
-      }
-    }
-
   } else {
     // ====================================================================
     // PROMPT NEUTRON SAMPLED
 
     // set the delayed group for the particle born from fission to 0
     site->delayed_group = 0;
+  }
 
-    // sample from prompt neutron energy distribution
-    int n_sample = 0;
-    while (true) {
-      rx.products_[0].sample(E_in, site->E, mu, seed);
+  // sample from prompt neutron energy distribution
+  int n_sample = 0;
+  double mu;
+  while (true) {
+    rx.products_[site->delayed_group].sample(E_in, site->E, mu, seed);
 
-      // resample if energy is greater than maximum neutron energy
-      constexpr int neutron = static_cast<int>(Particle::Type::neutron);
-      if (site->E < data::energy_max[neutron]) break;
+    // resample if energy is greater than maximum neutron energy
+    constexpr int neutron = static_cast<int>(Particle::Type::neutron);
+    if (site->E < data::energy_max[neutron]) break;
 
-      // check for large number of resamples
-      ++n_sample;
-      if (n_sample == MAX_SAMPLE) {
-        // particle_write_restart(p)
-        fatal_error("Resampled energy distribution maximum number of times "
-          "for nuclide " + nuc->name_);
-      }
+    // check for large number of resamples
+    ++n_sample;
+    if (n_sample == MAX_SAMPLE) {
+      // particle_write_restart(p)
+      fatal_error("Resampled energy distribution maximum number of times "
+        "for nuclide " + nuc->name_);
     }
   }
 
   // Sample azimuthal angle uniformly in [0, 2*pi) and assign angle
+  // TODO: use rotate_angle instead
   double phi = 2.0*PI*prn(seed);
   site->u.x = mu;
   site->u.y = std::sqrt(1.0 - mu*mu) * std::cos(phi);

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -1011,24 +1011,13 @@ sample_cxs_target_velocity(double awr, double E, Direction u, double kT, uint64_
 
 void sample_fission_neutron(int i_nuclide, const Reaction& rx, double E_in, Particle::Bank* site, uint64_t* seed)
 {
-  // Sample cosine of angle -- fission neutrons are always emitted
-  // isotropically. Sometimes in ACE data, fission reactions actually have
-  // an angular distribution listed, but for those that do, it's simply just
-  // a uniform distribution in mu
-  double mu = 2.0 * prn(seed) - 1.0;
-
-  // Sample azimuthal angle uniformly in [0,2*pi)
-  double phi = 2.0*PI*prn(seed);
-  site->u.x = mu;
-  site->u.y = std::sqrt(1.0 - mu*mu) * std::cos(phi);
-  site->u.z = std::sqrt(1.0 - mu*mu) * std::sin(phi);
-
   // Determine total nu, delayed nu, and delayed neutron fraction
   const auto& nuc {data::nuclides[i_nuclide]};
   double nu_t = nuc->nu(E_in, Nuclide::EmissionMode::total);
   double nu_d = nuc->nu(E_in, Nuclide::EmissionMode::delayed);
   double beta = nu_d / nu_t;
 
+  double mu;
   if (prn(seed) < beta) {
     // ====================================================================
     // DELAYED NEUTRON SAMPLED
@@ -1098,6 +1087,12 @@ void sample_fission_neutron(int i_nuclide, const Reaction& rx, double E_in, Part
       }
     }
   }
+
+  // Sample azimuthal angle uniformly in [0, 2*pi) and assign angle
+  double phi = 2.0*PI*prn(seed);
+  site->u.x = mu;
+  site->u.y = std::sqrt(1.0 - mu*mu) * std::cos(phi);
+  site->u.z = std::sqrt(1.0 - mu*mu) * std::sin(phi);
 }
 
 void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p)

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -63,25 +63,6 @@ Reaction::Reaction(hid_t group, const std::vector<int>& temperatures)
       close_group(pgroup);
     }
   }
-
-  // <<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<
-  // Before the secondary distribution refactor, when the angle/energy
-  // distribution was uncorrelated, no angle was actually sampled. With
-  // the refactor, an angle is always sampled for an uncorrelated
-  // distribution even when no angle distribution exists in the ACE file
-  // (isotropic is assumed). To preserve the RNG stream, we explicitly
-  // mark fission reactions so that we avoid the angle sampling.
-  if (is_fission(mt_)) {
-    for (auto& p : products_) {
-      if (p.particle_ == Particle::Type::neutron) {
-        for (auto& d : p.distribution_) {
-          auto d_ = dynamic_cast<UncorrelatedAngleEnergy*>(d.get());
-          if (d_) d_->fission() = true;
-        }
-      }
-    }
-  }
-  // <<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<
 }
 
 double

--- a/src/relaxng/settings.rnc
+++ b/src/relaxng/settings.rnc
@@ -154,8 +154,6 @@ element settings {
 
   element temperature_default { xsd:double }? &
 
-  element temperature_method { xsd:string }? &
-
   element temperature_multipole { xsd:boolean }? &
 
   element temperature_range { list { xsd:double, xsd:double } }? &

--- a/src/relaxng/settings.rng
+++ b/src/relaxng/settings.rng
@@ -691,11 +691,6 @@
       </element>
     </optional>
     <optional>
-      <element name="temperature_method">
-        <data type="string"/>
-      </element>
-    </optional>
-    <optional>
       <element name="temperature_multipole">
         <data type="boolean"/>
       </element>

--- a/src/secondary_correlated.cpp
+++ b/src/secondary_correlated.cpp
@@ -155,14 +155,6 @@ CorrelatedAngleEnergy::CorrelatedAngleEnergy(hid_t group)
 void CorrelatedAngleEnergy::sample(double E_in, double& E_out, double& mu,
   uint64_t* seed) const
 {
-  // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-  // Before the secondary distribution refactor, an isotropic polar cosine was
-  // always sampled but then overwritten with the polar cosine sampled from the
-  // correlated distribution. To preserve the random number stream, we keep
-  // this dummy sampling here but can remove it later (will change answers)
-  mu = 2.0*prn(seed) - 1.0;
-  // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
   // Find energy bin and calculate interpolation factor -- if the energy is
   // outside the range of the tabulated energies, choose the first or last bins
   auto n_energy_in = energy_.size();

--- a/src/secondary_kalbach.cpp
+++ b/src/secondary_kalbach.cpp
@@ -115,14 +115,6 @@ KalbachMann::KalbachMann(hid_t group)
 
 void KalbachMann::sample(double E_in, double& E_out, double& mu, uint64_t* seed) const
 {
-  // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-  // Before the secondary distribution refactor, an isotropic polar cosine was
-  // always sampled but then overwritten with the polar cosine sampled from the
-  // correlated distribution. To preserve the random number stream, we keep
-  // this dummy sampling here but can remove it later (will change answers)
-  mu = 2.0*prn(seed) - 1.0;
-  // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
   // Find energy bin and calculate interpolation factor -- if the energy is
   // outside the range of the tabulated energies, choose the first or last bins
   auto n_energy_in = energy_.size();

--- a/src/secondary_uncorrelated.cpp
+++ b/src/secondary_uncorrelated.cpp
@@ -55,12 +55,7 @@ UncorrelatedAngleEnergy::sample(double E_in, double& E_out, double& mu,
   uint64_t* seed) const
 {
   // Sample cosine of scattering angle
-  if (fission_) {
-    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-    // For fission, the angle is not used, so just assign a dummy value
-    mu = 1.0;
-    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-  } else if (!angle_.empty()) {
+  if (!angle_.empty()) {
     mu = angle_.sample(E_in, seed);
   } else {
     // no angle distribution given => assume isotropic for all energies

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -102,7 +102,6 @@ std::unordered_set<int> sourcepoint_batch;
 std::unordered_set<int> statepoint_batch;
 std::unordered_set<int> source_write_surf_id;
 int64_t max_surface_particles;
-TemperatureMethod temperature_method {TemperatureMethod::NEAREST};
 double temperature_tolerance {10.0};
 double temperature_default {293.6};
 std::array<double, 2> temperature_range {0.0, 0.0};
@@ -762,16 +761,6 @@ void read_settings_xml()
   // Get temperature settings
   if (check_for_node(root, "temperature_default")) {
     temperature_default = std::stod(get_node_value(root, "temperature_default"));
-  }
-  if (check_for_node(root, "temperature_method")) {
-    auto temp = get_node_value(root, "temperature_method", true, true);
-    if (temp == "nearest") {
-      temperature_method = TemperatureMethod::NEAREST;
-    } else if (temp == "interpolation") {
-      temperature_method = TemperatureMethod::INTERPOLATION;
-    } else {
-      fatal_error("Unknown temperature method: " + temp);
-    }
   }
   if (check_for_node(root, "temperature_tolerance")) {
     temperature_tolerance = std::stod(get_node_value(root, "temperature_tolerance"));

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -96,8 +96,10 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
     }
   } else {
     for (double T_desired : temperature) {
-      auto T_upper_it = std::lower_bound(
-        temps_available.begin(), temps_available.end(), T_desired);
+      auto T_upper_it = std::lower_bound(temps_available.begin(),
+        temps_available.end(), T_desired, [](const double& l, const double& r) {
+          return std::round(l) < std::round(r);
+        });
       if (T_upper_it == temps_available.end() ||
           T_upper_it == temps_available.begin()) {
         fatal_error(
@@ -109,7 +111,7 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
       // load both bounding temperatures.
       if (!contains(temps_to_read, *T_upper_it))
         temps_to_read.push_back(std::round(*T_upper_it));
-      if (T_desired != *T_upper_it) {
+      if (std::round(T_desired) != std::round(*T_upper_it)) {
         T_upper_it--;
         if (!contains(temps_to_read, *T_upper_it))
           temps_to_read.push_back(std::round(*T_upper_it));


### PR DESCRIPTION
Hey Paul,

So, to review, this PR's goal is to remove some code that I believe is extraneous and also potentially confusing for new users. For instance, if someone sets a fuel temperature to 700K, the error will likely be something along the lines of saying there's no data library at or near that value, so you ordinarily have to either raise temperature_tolerance (and basically get the wrong answer) or switch to interpolation mode.

The motivating factor for nearest mode is for testing purposes. When we have a temperature near a library temperature, we want to just use that without interpolation. In particular, for regression tests with only one temperature available, we need this behavior.

This PR changes the default behavior up. Now, interpolation mode is ALWAYS used. Now, the interesting addition is that we never need to use nearest interpolation. By default now, we use nearest interpolation only if there is one temperature in a nuclide data library. Otherwise, interpolation is used. Moreover, if the temperature to interpolate to rounds to the same temperature that a nuclide XS library is available at, only that library will be used, without using bounding temperature libraries. I think that by properly handling these edge cases, we can remove nearest interpolation mode and reduce branching in our XS lookup code slightly. I have already adopted this approach on GPU and hope to get it into the CPU code to ensure reproducibility, as this does change the RNG stream. Namely, in cases that previously used nearest interpolation, we do one more RNG sample in the XS lookup kernel than before.

Currently, I have only tested that the edge case handling as mentioned above works correctly by printing the data libraries we  read out. I am yet to test whether this gives correct interpolation behavior, and am open to ideas as to how we can prove this is giving the right answer.