### PR TITLE
added test for sab xs appears in xs calc

### DIFF
--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -1,0 +1,27 @@
+import openmc
+import numpy as np
+
+
+def test_calculate_cexs_elem_mat_sab():
+    """Checks that sab cross sections are included in the
+    _calculate_cexs_elem_mat method and have the correct shape"""
+
+    mat_1 = openmc.Material()
+    mat_1.add_element("H", 4.0, "ao")
+    mat_1.add_element("O", 4.0, "ao")
+    mat_1.add_element("C", 4.0, "ao")
+
+    mat_1.add_s_alpha_beta("c_C6H6")
+    mat_1.set_density("g/cm3", 0.865)
+
+    energy_grid, data = openmc.plotter._calculate_cexs_elem_mat(
+        mat_1,
+        ["inelastic"],
+        sab_name="c_C6H6",
+    )
+
+    assert isinstance(energy_grid, np.ndarray)
+    assert isinstance(data, np.ndarray)
+    assert len(energy_grid) > 1
+    assert len(data) == 1
+    assert len(data[0]) == len(energy_grid)


### PR DESCRIPTION
While reviewing #2335 I noticed our coverage test for ```openmc/plotter.py``` is one of the lowest files [at 6.59%](https://coveralls.io/builds/55630638/source?filename=openmc%2Fplotter.py#L5)

I thought this sab fix PR might be an opportunity to ensure the bug doesn't come back but also increase our test coverage.

So I made a small unit test for the ```_calculate_cexs_elem_mat_sab``` method that checks for the sab cross section generation for your consideration @paulromano 
