### PR TITLE
suggested changes: heating according to reaction q value

### DIFF
--- a/docs/source/methods/energy_deposition.rst
+++ b/docs/source/methods/energy_deposition.rst
@@ -47,14 +47,15 @@ interactions, the energy-balance KERMA coefficient is
 
 where :math:`\bar{E}_{i, r, n}` is the average energy of secondary neutrons and
 :math:`\bar{E}_{i, r, \gamma}` is the average energy of secondary photons. For
-photon and charged particle interactions, the :math:`Q` value is zero and thus
-the KERMA coefficient is
+photon and charged particle interactions the KERMA coefficient is
 
 .. math::
     :label: energy-balance-photon
 
-    k_{i, r}(E) = \left(E - \sum\limits_x \bar{E}_{i, r, x}
+    k_{i, r}(E) = \left(E + Q_{i, r} - \sum\limits_x \bar{E}_{i, r, x}
     \right)\sigma_{i, r}(E).
+    
+where the :math:`Q` value is zero for all interactions except for pair production and positron annihilation.    
 
 -------
 Fission

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -573,7 +573,8 @@ public:
   bool& fission() { return fission_; }            // true if implicit fission
   int& event_nuclide() { return event_nuclide_; } // index of collision nuclide
   const int& event_nuclide() const { return event_nuclide_; }
-  int& event_mt() { return event_mt_; }           // MT number of collision
+  int& event_mt() { return event_mt_; } // MT number of collision
+  const int& event_mt() const { return event_mt_; }
   int& delayed_group() { return delayed_group_; } // delayed group
   const int& parent_nuclide() const { return parent_nuclide_; }
   int& parent_nuclide() { return parent_nuclide_; } // Parent nuclide

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -441,11 +441,6 @@ void sample_photon_reaction(Particle& p)
     u = rotate_angle(p.u(), mu_positron, nullptr, p.current_seed());
     p.create_secondary(p.wgt(), u, E_positron, ParticleType::positron);
 
-    // Add 2 times electron rest mass energy to banked energy since the positron
-    // will annihilate later. This ensures that the energy deposited is not
-    // overestimated here
-    p.bank_second_E() += 2.0 * MASS_ELECTRON_EV;
-
     p.event() = TallyEvent::ABSORB;
     p.event_mt() = PAIR_PROD;
     p.wgt() = 0.0;
@@ -479,11 +474,9 @@ void sample_positron_reaction(Particle& p)
   // Sample angle isotropically
   Direction u = isotropic_direction(p.current_seed());
 
-  // Create annihilation photon pair traveling in opposite directions, but don't
-  // add their energy to the banked energy to avoid negative heating
+  // Create annihilation photon pair traveling in opposite directions
   p.create_secondary(p.wgt(), u, MASS_ELECTRON_EV, ParticleType::photon);
   p.create_secondary(p.wgt(), -u, MASS_ELECTRON_EV, ParticleType::photon);
-  p.bank_second_E() -= 2.0 * MASS_ELECTRON_EV;
 
   p.E() = 0.0;
   p.wgt() = 0.0;

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -325,6 +325,21 @@ double score_neutron_heating(const Particle& p, const Tally& tally, double flux,
   return score;
 }
 
+//! Helper function to obtain reaction Q value for photons and charged particles
+//! [eV]
+double get_reaction_q_value(const Particle& p)
+{
+  if (p.type() == ParticleType::photon) {
+    if (p.event_mt() == PAIR_PROD)
+      return -2 * MASS_ELECTRON_EV;
+  } else if (p.type() == ParticleType::positron) {
+    // positrons end their life in positron annihilation
+    return 2 * MASS_ELECTRON_EV;
+  }
+  // for most reactions the Q-value is 0
+  return 0.0;
+}
+
 //! Helper function to obtain particle heating [eV]
 
 double score_particle_heating(const Particle& p, const Tally& tally,
@@ -335,11 +350,13 @@ double score_particle_heating(const Particle& p, const Tally& tally,
       p, tally, flux, rxn_bin, i_nuclide, atom_density);
   if (i_nuclide == -1 || i_nuclide == p.event_nuclide() ||
       p.event_nuclide() == -1) {
+    // Get the reaction Q-value
+    double Q = get_reaction_q_value(p);
     // Get the pre-collision energy of the particle.
     auto E = p.E_last();
-    // The energy deposited is the difference between the pre-collision
-    // and post-collision energy...
-    double score = E - p.E();
+    // The energy deposited is the sum of the Q-value and the
+    // difference between the pre-collision and post-collision energy...
+    double score = Q + E - p.E();
     // ...less the energy of any secondary particles since they will be
     // transported individually later
     score -= p.bank_second_E();


### PR DESCRIPTION
Hi Paul,

I changed the heating logic in your branch to be compatible with the idea of Q-value (rest mass difference in terms of energy).
Now photon and charged particles heating behave similar to neutron heating.

I suggest these changes to your branch.

If you think they are reasonable you're invited to accept them.

Guy